### PR TITLE
[codex] Add opt-in Python gfal RSE protocol

### DIFF
--- a/lib/rucio/rse/protocols/gfal_python.py
+++ b/lib/rucio/rse/protocols/gfal_python.py
@@ -1,0 +1,366 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import errno
+import json
+import logging
+import os
+import posixpath
+import re
+from shutil import copyfileobj
+from urllib.parse import urlparse, urlunsplit
+
+from rucio.common import config, exception
+from rucio.common.checksum import GLOBALLY_SUPPORTED_CHECKSUMS, PREFERRED_CHECKSUM
+from rucio.common.constraints import STRING_TYPES
+from rucio.rse.protocols import protocol
+
+try:
+    from gfal import GfalClient
+except Exception:
+    if "RUCIO_CLIENT_MODE" not in os.environ:
+        if not config.config_has_section("database"):
+            raise exception.MissingDependency("Missing dependency : gfal")
+    else:
+        if os.environ["RUCIO_CLIENT_MODE"]:
+            raise exception.MissingDependency("Missing dependency : gfal")
+
+TIMEOUT = config.config_get("deletion", "timeout", False, None)
+COPY_BUFSIZE = 1024 * 1024
+
+
+class Default(protocol.RSEProtocol):
+    """RSE protocol implementation backed by the Python ``gfal`` library."""
+
+    def lfns2pfns(self, lfns):
+        """Return a fully qualified PFN for each LFN."""
+        lfns = [lfns] if isinstance(lfns, dict) else lfns
+
+        pfns = {}
+        prefix = self.attributes["prefix"]
+        if self.attributes["extended_attributes"] is not None and "web_service_path" in list(self.attributes["extended_attributes"].keys()):
+            web_service_path = self.attributes["extended_attributes"]["web_service_path"]
+        else:
+            web_service_path = ""
+
+        if not prefix.startswith("/"):
+            prefix = "".join(["/", prefix])
+        if not prefix.endswith("/"):
+            prefix = "".join([prefix, "/"])
+
+        hostname = self.attributes["hostname"]
+        if "://" in hostname:
+            hostname = hostname.split("://")[1]
+
+        if self.attributes["port"] == 0:
+            for lfn in lfns:
+                scope, name = str(lfn["scope"]), lfn["name"]
+                path = lfn["path"] if "path" in lfn and lfn["path"] else self._get_path(scope=scope, name=name)
+                if self.attributes["scheme"] != "root" and path.startswith("/"):
+                    path = path[1:]
+                pfns["%s:%s" % (scope, name)] = "".join([self.attributes["scheme"], "://", hostname, web_service_path, prefix, path])
+        else:
+            for lfn in lfns:
+                scope, name = str(lfn["scope"]), lfn["name"]
+                path = lfn["path"] if "path" in lfn and lfn["path"] else self._get_path(scope=scope, name=name)
+                if self.attributes["scheme"] != "root" and path.startswith("/"):
+                    path = path[1:]
+                if re.match(r"^\w+://", path):
+                    pfns["%s:%s" % (scope, name)] = path
+                else:
+                    pfns["%s:%s" % (scope, name)] = "".join([self.attributes["scheme"], "://", hostname, ":", str(self.attributes["port"]), web_service_path, prefix, path])
+
+        return pfns
+
+    def parse_pfns(self, pfns):
+        """Split a PFN into protocol parts and validate it against the RSE."""
+        self.logger(logging.DEBUG, "parsing {} pfns".format(len(list(pfns))))
+        ret = dict()
+        pfns = [pfns] if isinstance(pfns, STRING_TYPES) else pfns
+        for pfn in pfns:
+            parsed = urlparse(pfn)
+            if parsed.path.startswith("/srm/managerv2") or parsed.path.startswith("/srm/managerv1") or parsed.path.startswith("/srm/v2/server"):
+                scheme, hostname, port, service_path, path = re.findall(r"([^:]+)://([^:/]+):?(\d+)?([^:]+=)?([^:]+)", pfn)[0]
+            else:
+                scheme = parsed.scheme
+                hostname = parsed.netloc.partition(":")[0]
+                port = parsed.netloc.partition(":")[2]
+                path = parsed.path
+                service_path = ""
+
+            if self.attributes["hostname"] != hostname and self.attributes["hostname"] != scheme + "://" + hostname:
+                raise exception.RSEFileNameNotSupported("Invalid hostname: provided '%s', expected '%s'" % (hostname, self.attributes["hostname"]))
+
+            if port != "" and str(self.attributes["port"]) != str(port):
+                raise exception.RSEFileNameNotSupported("Invalid port: provided '%s', expected '%s'" % (port, self.attributes["port"]))
+            elif port == "":
+                port = self.attributes["port"]
+
+            if not path.startswith(self.attributes["prefix"]):
+                raise exception.RSEFileNameNotSupported("Invalid prefix: provided '%s', expected '%s'" % ("/".join(path.split("/")[0 : len(self.attributes["prefix"].split("/")) - 1]), self.attributes["prefix"]))
+
+            prefix = self.attributes["prefix"]
+            path = path.partition(self.attributes["prefix"])[2]
+            name = path.split("/")[-1]
+            path = "/".join(path.split("/")[:-1])
+            if not path.startswith("/"):
+                path = "/" + path
+            if path != "/" and not path.endswith("/"):
+                path = path + "/"
+            ret[pfn] = {"scheme": scheme, "port": port, "hostname": hostname, "path": path, "name": name, "prefix": prefix, "web_service_path": service_path}
+
+        return ret
+
+    def path2pfn(self, path):
+        """Return a fully qualified PFN for ``path``."""
+        self.logger(logging.DEBUG, "getting pfn for {}".format(path))
+
+        if "://" in path:
+            return path
+
+        hostname = self.attributes["hostname"]
+        if "://" in hostname:
+            hostname = hostname.split("://")[1]
+
+        if "extended_attributes" in list(self.attributes.keys()) and self.attributes["extended_attributes"] is not None and "web_service_path" in list(self.attributes["extended_attributes"].keys()):
+            web_service_path = self.attributes["extended_attributes"]["web_service_path"]
+        else:
+            web_service_path = ""
+
+        if not path.startswith("srm"):
+            if self.attributes["port"] > 0:
+                return "".join([self.attributes["scheme"], "://", hostname, ":", str(self.attributes["port"]), web_service_path, path])
+            return "".join([self.attributes["scheme"], "://", hostname, web_service_path, path])
+        return path
+
+    def connect(self):
+        """Prepare the Python ``gfal`` client configuration."""
+        self.logger(logging.DEBUG, "connecting to storage via Python gfal")
+        self._client_kwargs = {}
+
+        if TIMEOUT:
+            try:
+                self._client_kwargs["timeout"] = int(TIMEOUT)
+            except ValueError:
+                self.logger(logging.ERROR, "wrong timeout value %s", TIMEOUT)
+
+        proxy = config.config_get("client", "client_x509_proxy", default=None, raise_exception=False)
+        if proxy:
+            self.logger(logging.INFO, "Configuring authentication to use {}".format(proxy))
+            self._client_kwargs["cert"] = proxy
+            self._client_kwargs["key"] = proxy
+
+    def close(self):
+        """Close the protocol connection."""
+        self.logger(logging.DEBUG, "closing protocol connection")
+        self._client_kwargs = None
+
+    @contextlib.contextmanager
+    def _auth_environment(self):
+        previous_token = os.environ.get("BEARER_TOKEN")
+        if self.auth_token:
+            os.environ["BEARER_TOKEN"] = self.auth_token
+        try:
+            yield
+        finally:
+            if self.auth_token:
+                if previous_token is None:
+                    os.environ.pop("BEARER_TOKEN", None)
+                else:
+                    os.environ["BEARER_TOKEN"] = previous_token
+
+    def _make_client(self, timeout=None):
+        kwargs = dict(getattr(self, "_client_kwargs", {}) or {})
+        if timeout:
+            kwargs["timeout"] = int(timeout)
+        return GfalClient(**kwargs)
+
+    @staticmethod
+    def _local_path(path):
+        if path.startswith("file://"):
+            return urlparse(path).path
+        return os.path.abspath(path)
+
+    @staticmethod
+    def _parent_url(url):
+        parsed = urlparse(str(url))
+        parent_path = posixpath.dirname(parsed.path.rstrip("/"))
+        if not parent_path:
+            parent_path = "/"
+        return urlunsplit((parsed.scheme, parsed.netloc, parent_path, parsed.query, parsed.fragment))
+
+    @staticmethod
+    def _is_not_found(error):
+        return isinstance(error, FileNotFoundError) or getattr(error, "errno", None) == errno.ENOENT or "No such file" in str(error)
+
+    def exists(self, path):
+        """Return ``True`` if the PFN exists, else ``False``."""
+        self.logger(logging.DEBUG, "checking if file exists {}".format(path))
+        if path is None:
+            raise exception.RSEOperationNotSupported()
+
+        try:
+            with self._auth_environment():
+                self._make_client().stat(str(path))
+            return True
+        except Exception as error:
+            if self._is_not_found(error):
+                return False
+            raise exception.ServiceUnavailable(error)
+
+    def get(self, path, dest, transfer_timeout=None):
+        """Download a remote PFN to a local destination."""
+        self.logger(logging.DEBUG, "downloading file from {} to {}".format(path, dest))
+        local_dest = self._local_path(dest)
+        client = self._make_client(timeout=transfer_timeout)
+        try:
+            with self._auth_environment():
+                source_handle = client.open(str(path), "rb")
+        except Exception as error:
+            if self._is_not_found(error):
+                raise exception.SourceNotFound(error)
+            raise exception.ServiceUnavailable(error)
+
+        try:
+            with source_handle:
+                with open(local_dest, "wb") as dest_handle:
+                    copyfileobj(source_handle, dest_handle, COPY_BUFSIZE)
+        except OSError as error:
+            raise exception.DestinationNotAccessible(error)
+        except Exception as error:
+            raise exception.ServiceUnavailable(error)
+
+    def put(self, source, target, source_dir, transfer_timeout=None):
+        """Upload a local file to a remote PFN."""
+        self.logger(logging.DEBUG, "uploading file from {} to {}".format(source, target))
+        source_path = "%s/%s" % (source_dir, source) if source_dir else source
+        local_source = self._local_path(source_path)
+        if not os.path.exists(local_source):
+            raise exception.SourceNotFound()
+
+        client = self._make_client(timeout=transfer_timeout)
+        try:
+            with self._auth_environment():
+                client.mkdir(self._parent_url(target), parents=True)
+                with open(local_source, "rb") as source_handle:
+                    with client.open(str(target), "wb") as dest_handle:
+                        copyfileobj(source_handle, dest_handle, COPY_BUFSIZE)
+        except OSError as error:
+            if self._is_not_found(error):
+                raise exception.SourceNotFound(error)
+            raise exception.DestinationNotAccessible(error)
+        except Exception as error:
+            if self._is_not_found(error):
+                raise exception.SourceNotFound(error)
+            raise exception.ServiceUnavailable(error)
+
+    def delete(self, path):
+        """Delete one or more PFNs from the connected RSE."""
+        self.logger(logging.DEBUG, "deleting file {}".format(path))
+        pfns = [path] if isinstance(path, STRING_TYPES) else path
+        client = self._make_client()
+        try:
+            with self._auth_environment():
+                for pfn in pfns:
+                    client.rm(str(pfn))
+        except Exception as error:
+            if self._is_not_found(error):
+                raise exception.SourceNotFound(error)
+            raise exception.ServiceUnavailable(error)
+
+    def rename(self, path, new_path):
+        """Rename a PFN on the connected RSE."""
+        self.logger(logging.DEBUG, "renaming file from {} to {}".format(path, new_path))
+        client = self._make_client()
+        try:
+            with self._auth_environment():
+                with contextlib.suppress(Exception):
+                    client.mkdir(self._parent_url(new_path), parents=True)
+                client.rename(str(path), str(new_path))
+        except Exception as error:
+            if self._is_not_found(error):
+                raise exception.SourceNotFound(error)
+            raise exception.ServiceUnavailable(error)
+
+    def stat(self, path):
+        """Return file size and checksum metadata for a PFN."""
+        self.logger(logging.DEBUG, "getting stats of file {}".format(path))
+        ret = {}
+        client = self._make_client()
+        try:
+            with self._auth_environment():
+                stat_result = client.stat(str(path))
+        except Exception as error:
+            raise exception.ServiceUnavailable("Error while processing gfal stat call. Error: %s" % str(error))
+
+        ret["filesize"] = int(stat_result.st_size)
+        if not self.rse.get("verify_checksum", True):
+            return ret
+
+        message = "\n"
+        try:
+            with self._auth_environment():
+                ret[PREFERRED_CHECKSUM] = client.checksum(str(path), str(PREFERRED_CHECKSUM.upper()))
+            return ret
+        except Exception as error:
+            message += "Error while processing gfal checksum call (%s). Error: %s \n" % (PREFERRED_CHECKSUM, str(error))
+
+        for checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS:
+            if checksum_name == PREFERRED_CHECKSUM:
+                continue
+            try:
+                with self._auth_environment():
+                    ret[checksum_name] = client.checksum(str(path), str(checksum_name.upper()))
+                return ret
+            except Exception as error:
+                message += "Error while processing gfal checksum call (%s). Error: %s \n" % (checksum_name, str(error))
+
+        raise exception.RSEChecksumUnavailable(message)
+
+    def get_space_usage(self):
+        """Return ``(totalsize, unusedsize)`` from the space-token xattr."""
+        endpoint_basepath = self.path2pfn(self.attributes["prefix"])
+        self.logger(logging.DEBUG, "getting space usage from {}".format(endpoint_basepath))
+
+        space_token = None
+        if self.attributes["extended_attributes"] is not None and "space_token" in list(self.attributes["extended_attributes"].keys()):
+            space_token = self.attributes["extended_attributes"]["space_token"]
+
+        if space_token is None or space_token == "":
+            raise exception.RucioException("Space token is not defined for protocol: %s" % (self.attributes["scheme"]))
+
+        client = self._make_client()
+        try:
+            with self._auth_environment():
+                ret_usage = client.getxattr(str(endpoint_basepath), str("spacetoken.description?" + space_token))
+            usage = json.loads(ret_usage)
+            totalsize = usage[0]["totalsize"]
+            unusedsize = usage[0]["unusedsize"]
+            return totalsize, unusedsize
+        except Exception as error:
+            raise exception.ServiceUnavailable(error)
+
+
+class NoRename(Default):
+    """Same as ``Default`` but without the upload temp-file rename step."""
+
+    def __init__(self, protocol_attr, rse_settings, logger=logging.log):
+        super(NoRename, self).__init__(protocol_attr, rse_settings, logger=logger)
+        self.renaming = False
+        self.attributes.pop("determinism_type", None)
+        self.files = []
+
+    def rename(self, pfn, new_pfn):
+        raise NotImplementedError

--- a/pyproject.client.toml
+++ b/pyproject.client.toml
@@ -31,7 +31,8 @@ dependencies = [
         'tabulate',
         'jsonschema',
         'rich',
-        'typing_extensions'
+        'typing_extensions',
+        'gfal<=0.1.41'
 ]
 requires-python = ">=3.9"
 authors = [

--- a/pyproject.server.toml
+++ b/pyproject.server.toml
@@ -46,6 +46,7 @@ dependencies = [
   'flask<=3.1.2',
   'oic<=1.7.0',
   'prometheus_client<=0.23.1',
+  'gfal<=0.1.41',
 ]
 requires-python = ">=3.9"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   'flask<=3.1.3',
   'oic<=1.7.0',
   'prometheus_client<=0.23.1',
+  'gfal<=0.1.41',
 ]
 requires-python = ">=3.9"
 authors = [

--- a/requirements/requirements.client.txt
+++ b/requirements/requirements.client.txt
@@ -8,6 +8,7 @@ packaging>=25.0                                             # Packaging utilitie
 rich>=14.2.0                                                # For Rich terminal display
 typing-extensions>=4.15.0                                   # Type annotations that are not yet supported in the `typing` module
 click>=8.3.0                                                # CLI engine
+gfal>=0.1.41                                               # Python GFAL replacement used by the opt-in gfal protocol backend
 
 # All dependencies needed in extras for rucio client should be defined here
 paramiko>=4.0.0                                             # ssh_extras; SSH2 protocol library (also needed in the server)

--- a/requirements/requirements.server.in
+++ b/requirements/requirements.server.in
@@ -41,3 +41,4 @@ elasticsearch==8.15.1                                        # elasticsearch (me
 libtorrent==2.0.11                                          # Support for the bittorrent transfertool
 qbittorrent-api==2025.7.0                                   # qBittorrent plugin for the bittorrent tranfsertool
 rich==14.2.0                                                # For Rich terminal display
+gfal==0.1.41                                                # Python GFAL replacement used by the opt-in gfal protocol backend

--- a/requirements/requirements.server.txt
+++ b/requirements/requirements.server.txt
@@ -84,6 +84,8 @@ future==1.0.0
     # via pyjwkest
 geoip2==5.1.0
     # via -r requirements.server.in
+gfal==0.1.41
+    # via -r requirements.server.in
 globus-sdk==4.1.0
     # via -r requirements.server.in
 google-auth==2.42.1

--- a/tests/test_rse_protocol_gfal_python.py
+++ b/tests/test_rse_protocol_gfal_python.py
@@ -1,0 +1,202 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import io
+import os
+import sys
+import types
+
+
+def _load_module(monkeypatch, client_cls):
+    fake_gfal = types.ModuleType("gfal")
+    fake_gfal.GfalClient = client_cls
+    monkeypatch.setitem(sys.modules, "gfal", fake_gfal)
+    sys.modules.pop("rucio.rse.protocols.gfal_python", None)
+    module = importlib.import_module("rucio.rse.protocols.gfal_python")
+    return importlib.reload(module)
+
+
+def _make_protocol(module, protocol_class_name="Default"):
+    protocol_attr = {
+        "scheme": "https",
+        "hostname": "storage.example",
+        "port": 443,
+        "prefix": "/rucio",
+        "impl": "rucio.rse.protocols.gfal_python.%s" % protocol_class_name,
+        "domains": {"wan": {"read": 1, "write": 1, "delete": 1}},
+        "extended_attributes": {"space_token": "TOKEN"},
+        "auth_token": "secret-token",
+    }
+    rse_settings = {
+        "rse": "TEST_RSE",
+        "id": "test-rse-id",
+        "verify_checksum": True,
+        "deterministic": False,
+        "protocols": [dict(protocol_attr)],
+    }
+    protocol_cls = getattr(module, protocol_class_name)
+    protocol = protocol_cls(dict(protocol_attr), rse_settings, logger=lambda *args, **kwargs: None)
+    protocol.connect()
+    return protocol
+
+
+class FakeStat:
+    def __init__(self, size):
+        self.st_size = size
+
+
+class FakeClient:
+    instances = []
+    files = {}
+    checksums = {}
+    xattrs = {}
+    stats = {}
+    mkdir_calls = []
+    rename_calls = []
+    rm_calls = []
+    last_kwargs = None
+
+    def __init__(self, **kwargs):
+        FakeClient.last_kwargs = kwargs
+        FakeClient.instances.append(self)
+
+    @classmethod
+    def reset(cls):
+        cls.instances = []
+        cls.files = {}
+        cls.checksums = {}
+        cls.xattrs = {}
+        cls.stats = {}
+        cls.mkdir_calls = []
+        cls.rename_calls = []
+        cls.rm_calls = []
+        cls.last_kwargs = None
+
+    def stat(self, path):
+        if path not in self.stats:
+            raise FileNotFoundError(path)
+        return self.stats[path]
+
+    def checksum(self, path, algorithm):
+        return self.checksums[(path, algorithm)]
+
+    def getxattr(self, path, name):
+        return self.xattrs[(path, name)]
+
+    def mkdir(self, path, parents=False):
+        self.mkdir_calls.append((path, parents))
+
+    def rename(self, source, dest):
+        self.rename_calls.append((source, dest))
+
+    def rm(self, path):
+        self.rm_calls.append(path)
+
+    def open(self, path, mode="rb"):
+        if "r" in mode:
+            if path not in self.files:
+                raise FileNotFoundError(path)
+            return io.BytesIO(self.files[path])
+
+        buffer = io.BytesIO()
+        original_close = buffer.close
+
+        def _close():
+            self.files[path] = buffer.getvalue()
+            original_close()
+
+        buffer.close = _close
+        return buffer
+
+
+def test_stat_prefers_adler32(monkeypatch):
+    FakeClient.reset()
+    module = _load_module(monkeypatch, FakeClient)
+    protocol = _make_protocol(module)
+
+    FakeClient.stats["https://storage.example:443/rucio/file1"] = FakeStat(123)
+    FakeClient.checksums[("https://storage.example:443/rucio/file1", "ADLER32")] = "deadbeef"
+
+    result = protocol.stat("https://storage.example:443/rucio/file1")
+
+    assert result == {"filesize": 123, "adler32": "deadbeef"}
+
+
+def test_put_creates_parent_and_uploads(monkeypatch, tmp_path):
+    FakeClient.reset()
+    module = _load_module(monkeypatch, FakeClient)
+    protocol = _make_protocol(module)
+    local_file = tmp_path / "payload.bin"
+    local_file.write_bytes(b"payload-data")
+
+    protocol.put(str(local_file), "https://storage.example:443/rucio/dir/file.bin", source_dir=None, transfer_timeout=42)
+
+    assert FakeClient.mkdir_calls == [("https://storage.example:443/rucio/dir", True)]
+    assert FakeClient.files["https://storage.example:443/rucio/dir/file.bin"] == b"payload-data"
+    assert FakeClient.last_kwargs["timeout"] == 42
+    assert "BEARER_TOKEN" not in os.environ
+
+
+def test_get_downloads_to_local_path(monkeypatch, tmp_path):
+    FakeClient.reset()
+    module = _load_module(monkeypatch, FakeClient)
+    protocol = _make_protocol(module)
+    FakeClient.files["https://storage.example:443/rucio/data.bin"] = b"remote-data"
+
+    destination = tmp_path / "download.bin"
+    protocol.get("https://storage.example:443/rucio/data.bin", str(destination), transfer_timeout=15)
+
+    assert destination.read_bytes() == b"remote-data"
+    assert FakeClient.last_kwargs["timeout"] == 15
+
+
+def test_exists_false_for_missing_file(monkeypatch):
+    FakeClient.reset()
+    module = _load_module(monkeypatch, FakeClient)
+    protocol = _make_protocol(module)
+
+    assert protocol.exists("https://storage.example:443/rucio/missing.bin") is False
+
+
+def test_rename_creates_parent_before_rename(monkeypatch):
+    FakeClient.reset()
+    module = _load_module(monkeypatch, FakeClient)
+    protocol = _make_protocol(module)
+
+    protocol.rename("https://storage.example:443/rucio/source.bin", "https://storage.example:443/rucio/new/path/target.bin")
+
+    assert FakeClient.mkdir_calls == [("https://storage.example:443/rucio/new/path", True)]
+    assert FakeClient.rename_calls == [("https://storage.example:443/rucio/source.bin", "https://storage.example:443/rucio/new/path/target.bin")]
+
+
+def test_delete_handles_multiple_pfns(monkeypatch):
+    FakeClient.reset()
+    module = _load_module(monkeypatch, FakeClient)
+    protocol = _make_protocol(module)
+
+    protocol.delete(["https://storage.example:443/rucio/a.bin", "https://storage.example:443/rucio/b.bin"])
+
+    assert FakeClient.rm_calls == ["https://storage.example:443/rucio/a.bin", "https://storage.example:443/rucio/b.bin"]
+
+
+def test_get_space_usage_reads_xattr(monkeypatch):
+    FakeClient.reset()
+    module = _load_module(monkeypatch, FakeClient)
+    protocol = _make_protocol(module)
+    FakeClient.xattrs[("https://storage.example:443/rucio", "spacetoken.description?TOKEN")] = '[{"totalsize": 1000, "unusedsize": 400}]'
+
+    totalsize, unusedsize = protocol.get_space_usage()
+
+    assert (totalsize, unusedsize) == (1000, 400)


### PR DESCRIPTION
## Summary

This adds an opt-in RSE protocol backend for the Python `gfal` library alongside the existing `gfal2` backend.

The new implementation lives at `rucio.rse.protocols.gfal_python.Default` and keeps `rucio.rse.protocols.gfal.Default` unchanged.

## What changed

- added `lib/rucio/rse/protocols/gfal_python.py`
- implemented the core Rucio protocol operations on top of `gfal.GfalClient`
  - `connect`
  - `get`
  - `put`
  - `delete`
  - `rename`
  - `exists`
  - `stat`
  - `get_space_usage`
- added `NoRename` parity with the existing GFAL2 module
- added focused unit coverage in `tests/test_rse_protocol_gfal_python.py`
- added `gfal` to the Python dependency surfaces used by this repo
  - `pyproject.toml`
  - `pyproject.server.toml`
  - `pyproject.client.toml`
  - `requirements/requirements.server.in`
  - `requirements/requirements.server.txt`
  - `requirements/requirements.client.txt`

## Why

Rucio currently uses `gfal2` primarily in the RSE protocol backend in `lib/rucio/rse/protocols/gfal.py`, with additional `gfal2`-specific usage in the dumper and auditor paths.

The local integration findings in `/Users/lobis/git/gfal/docs/gfal2-library-integration-findings.md` showed that the Rucio protocol backend depends on a fairly small subset of the old GFAL2 surface:

- stat/existence
- local<->remote transfer
- delete
- rename
- checksum lookup
- selected xattrs / space-usage lookup

This PR wires in that subset first, as a separate opt-in implementation, so we can evaluate the Python `gfal` library in parallel without changing existing GFAL2 behavior.

## Dependency note

The new backend imports `gfal` directly, so adding just the protocol module would not be enough. This PR also adds the Python package dependency using the current PyPI release `gfal==0.1.41` / `gfal<=0.1.41`, and that flows into the Docker-based runtime/test image via the existing requirements install step.

## Notes

- this backend is intentionally opt-in via `impl: rucio.rse.protocols.gfal_python.Default`
- the existing `gfal2`-based backend is untouched
- the implementation streams local<->remote transfers through `gfal.GfalClient.open(...)` because the current Python `gfal` API does not yet expose a library-level `copy()` method matching GFAL2's `filecopy`
- the fork `lobis/rucio` does not currently have a `main` branch, so this PR targets `master`

## Validation

- `ruff format lib/rucio/rse/protocols/gfal_python.py tests/test_rse_protocol_gfal_python.py`
- `ruff check lib/rucio/rse/protocols/gfal_python.py tests/test_rse_protocol_gfal_python.py`
- `.venv/bin/python -m pytest tests/test_rse_protocol_gfal_python.py -q`
- `.venv/bin/python -m pytest tests/test_rse_protocol_gfal2.py -q` (all skipped in this local env)
- `.venv/bin/python -m pytest tests/test_rse_protocol_gfal2_impl.py -q` (all skipped in this local env)
- `PYTHONPATH=.:lib .venv/bin/python -c "import os; os.environ['RUCIO_CONFIG']='/Users/lobis/git/rucio/rucio/rucio.cfg'; import rucio.rse.protocols.gfal_python as m; print(m.Default.__name__)"`
